### PR TITLE
Use on all platforms

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,16 +108,14 @@ async function getLatestRelease(): Promise<{ tagName: string, url: string }> {
     throw new Error(`Received an error code from Github: ${response.status}`);
   }
   const { tag_name, assets } = JSON.parse(response.responseText);
-  const platform = os.platform();
-  const arch = os.arch();
+  const platform = os.platform() === 'win32'
+  ? 'pc-windows-msvc'
+  : os.platform() === 'darwin'
+    ? 'apple-darwin'
+    : 'unknown-linux-gnu';
+  const arch = os.arch() === 'arm64' ? 'aarch64' : 'x86_64';
   // these are the binaries built in redscript-ide on github
-  const binary = platform === "win32"
-  ? "redscript-ide.exe"
-  : platform === "darwin"
-    ? arch === "arm64"
-      ? "redscript-ide-apple-silicon"
-      : "redscript-ide-apple-intel"
-    : "redscript-ide-linux";
+  const binary = `redscript-ide-${arch}-${platform}`;
   const exe = assets.find((asset: any) => asset.name === binary);
   if (!exe) {
     throw new Error(`No ${binary} in the latest release`);


### PR DESCRIPTION
Allow extension to grab platform-dependent binary from [redscript-ide](https://github.com/jac3km4/redscript-ide)'s releases.

⚠️ This PR is tighly coupled to jac3km4/redscript-ide#3.