### PR TITLE
Add OpenVSX release to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
           args: "package"
       - name: Set version
         run: echo PACKAGE_VERSION=$(node -p 'require("./package.json").version') >> $GITHUB_ENV
+        
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,3 +23,8 @@ jobs:
           asset_path: ./redscript-ide-vscode-${{ env.PACKAGE_VERSION }}.vsix
           asset_name: redscript-ide-vscode-${{ env.PACKAGE_VERSION }}.vsix
           asset_content_type: application/vsix
+          
+      - name: Install OpenVSX
+        run: npm i -g ovsx@latest
+      - name: Deploying to OpenVSX Marketplace
+        run: ovsx publish -i ./redscript-ide-vscode-${{ env.PACKAGE_VERSION }}.vsix -p ${{ secrets.OVSX_PAT }}´


### PR DESCRIPTION
Will need `OVSX_PAT` secret to be set, which needs an [OpenVSX account](https://open-vsx.org/user-settings/tokens) and an Eclipse Foundation account apparently too ![:cat_hmm2:](https://cdn.discordapp.com/emojis/1194928540949422171.webp?size=16)